### PR TITLE
Bucket 3: Scraping robustness (dynamic stats stripping + type loop)

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -1,0 +1,17 @@
+// Tolerant fallback for when the live stats text is unavailable: strips the
+// leading stats bar, which is an optional run of labels ("Accuracy"/"Speed"/
+// "Time"/"Errors") followed by at least one numeric value token ("100%", "0WPM",
+// "0CPM", "60s", "0/0"). Requiring a numeric token prevents over-stripping a
+// passage that merely begins with one of those words (e.g. "Time flies").
+const STATS_PREFIX_RE =
+  /^(?:Accuracy|Speed|Time|Errors)*(?:\d+%|\d+\s*WPM|\d+\s*CPM|\d+s|\d+\/\d+)+/;
+
+function stripStatsPrefix(rawText, statsText) {
+  if (typeof rawText !== 'string') return '';
+  if (typeof statsText === 'string' && statsText && rawText.startsWith(statsText)) {
+    return rawText.slice(statsText.length);
+  }
+  return rawText.replace(STATS_PREFIX_RE, '');
+}
+
+module.exports = { stripStatsPrefix, STATS_PREFIX_RE };

--- a/src/typer.js
+++ b/src/typer.js
@@ -1,0 +1,13 @@
+const NEWLINE_MARKER = '⏎';
+
+async function typePassage(keyboard, text, { delayMs = 0 } = {}) {
+  for (const ch of text) {
+    if (ch === NEWLINE_MARKER) {
+      await keyboard.press('Enter');
+    } else {
+      await keyboard.type(ch, { delay: delayMs });
+    }
+  }
+}
+
+module.exports = { typePassage, NEWLINE_MARKER };

--- a/test/unit/text.test.js
+++ b/test/unit/text.test.js
@@ -1,0 +1,39 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { stripStatsPrefix } = require('../../src/text');
+
+const PASSAGE = 'The quick brown fox⏎jumps over';
+
+test('slices an exact known statsText off the front', () => {
+  const stats = 'AccuracySpeedTimeErrors100%0WPM0CPM60s0/0';
+  assert.equal(stripStatsPrefix(stats + PASSAGE, stats), PASSAGE);
+});
+
+test('regex fallback strips the stat run when statsText is null', () => {
+  const raw = 'AccuracySpeedTimeErrors100%0WPM0CPM60s0/0' + PASSAGE;
+  assert.equal(stripStatsPrefix(raw, null), PASSAGE);
+});
+
+test('returns text unchanged when there is no stats prefix', () => {
+  assert.equal(stripStatsPrefix(PASSAGE, null), PASSAGE);
+});
+
+test('non-string input yields empty string', () => {
+  assert.equal(stripStatsPrefix(null, null), '');
+  assert.equal(stripStatsPrefix(undefined, 'x'), '');
+});
+
+test('does not over-strip a passage starting with a bare stat word', () => {
+  // No numeric stat token follows, so the stats regex must not match.
+  assert.equal(stripStatsPrefix('Time flies when typing', null), 'Time flies when typing');
+  assert.equal(stripStatsPrefix('Accuracy is the goal', null), 'Accuracy is the goal');
+});
+
+test('still strips a glued labels+values stats bar via regex', () => {
+  assert.equal(stripStatsPrefix('Errors0/0Hello there', null), 'Hello there');
+});
+
+test('ignores a non-string statsText and falls back to the regex', () => {
+  const raw = 'AccuracySpeedTimeErrors100%0WPM0CPM60s0/0' + PASSAGE;
+  assert.equal(stripStatsPrefix(raw, 123), PASSAGE);
+});

--- a/test/unit/typer.test.js
+++ b/test/unit/typer.test.js
@@ -1,0 +1,39 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { typePassage, NEWLINE_MARKER } = require('../../src/typer');
+
+function fakeKeyboard() {
+  const calls = [];
+  return {
+    calls,
+    async type(ch, opts) { calls.push({ kind: 'type', ch, opts }); },
+    async press(key) { calls.push({ kind: 'press', key }); },
+  };
+}
+
+test('NEWLINE_MARKER is the return glyph', () => {
+  assert.equal(NEWLINE_MARKER, '⏎');
+});
+
+test('types each char and presses Enter for the newline marker', async () => {
+  const kb = fakeKeyboard();
+  await typePassage(kb, 'ab⏎c', { delayMs: 0 });
+  assert.deepEqual(kb.calls, [
+    { kind: 'type', ch: 'a', opts: { delay: 0 } },
+    { kind: 'type', ch: 'b', opts: { delay: 0 } },
+    { kind: 'press', key: 'Enter' },
+    { kind: 'type', ch: 'c', opts: { delay: 0 } },
+  ]);
+});
+
+test('passes the configured delay through to keyboard.type', async () => {
+  const kb = fakeKeyboard();
+  await typePassage(kb, 'x', { delayMs: 80 });
+  assert.equal(kb.calls[0].opts.delay, 80);
+});
+
+test('defaults delay to 0 when opts is omitted', async () => {
+  const kb = fakeKeyboard();
+  await typePassage(kb, 'x');
+  assert.equal(kb.calls[0].opts.delay, 0);
+});


### PR DESCRIPTION
## Bucket 3 — Scraping Robustness (pure logic modules)

Replaces the brittle hardcoded text cleanup and index-based typing loop from the original `FlashTyper.js` with two pure, unit-tested modules. The orchestrator that consumes them lands in the next bucket.

### Changes
- **`src/text.js` — `stripStatsPrefix(rawText, statsText)`** (part of #1127): derives the stats prefix instead of the old literal `replace("AccuracySpeedTimeErrors100%0WPM0CPM60s0/0", "")`. Uses a live-read `statsText` fast-path; falls back to a regex when unavailable.
- **`src/typer.js` — `typePassage(keyboard, text, {delayMs})`**: code-point-safe `for…of` loop, presses Enter on the `⏎` marker, and takes an injectable keyboard so the loop is unit-testable.
- **Tests**: `node:test` suites for both modules. Full suite now 15 unit tests, all passing.

### Reviewer follow-ups applied
- **Anti-over-strip hardening**: the regex now requires at least one numeric stat token, so a passage beginning with a bare word like `"Time flies"` or `"Accuracy is the goal"` is no longer truncated. Added tests covering this.
- **Type guard**: `statsText` is ignored unless it is a string (added test).
- **Test gaps**: added default-`delayMs` (opts omitted) and glued-stats-bar cases.

### Verification
`npm test` → 15 passed, 0 failed.

Note: hub task #1127 also covers the stable selector, which is wired into the orchestrator in the final (Bucket 2) PR; it will be marked resolved there.