### PR TITLE
Bucket 2: Browser lifecycle & error resilience (orchestrator)

### DIFF
--- a/FlashTyper.js
+++ b/FlashTyper.js
@@ -1,37 +1,74 @@
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+const puppeteer = require('puppeteer-extra');
+const StealthPlugin = require('puppeteer-extra-plugin-stealth');
+const { resolveConfig } = require('./src/config');
+const { stripStatsPrefix } = require('./src/text');
+const { typePassage } = require('./src/typer');
+
+// Register the stealth plugin once at module load. puppeteer-extra holds a
+// single shared instance, so registering here covers every runTyper() call and
+// any other module that requires this file.
+puppeteer.use(StealthPlugin());
+
+// Semantic, human-authored class — survives styled-components hash churn.
+const PASSAGE_SELECTOR = '.screen-display';
+// Best-effort live stats node; stripStatsPrefix falls back to regex if absent.
+const STATS_SELECTOR = '.screen-display .stats, .typing-stats';
+
+async function runTyper(config) {
+  let browser;
+  let context;
+  try {
+    browser = await puppeteer.launch({
+      headless: config.headless,
+      executablePath: config.executablePath,
+    });
+    // #1123: use an isolated context AND open the page from it.
+    context = await browser.createBrowserContext();
+    const page = await context.newPage();
+
+    await page.goto(config.url, { waitUntil: 'domcontentloaded' });
+
+    // #1125: wait for real readiness instead of a fixed sleep.
+    await page.waitForSelector(PASSAGE_SELECTOR, { timeout: config.waitTimeoutMs });
+
+    // #1121: guard against a null element. waitForSelector throws on timeout,
+    // but the node could still detach between that call and this query.
+    const element = await page.$(PASSAGE_SELECTOR);
+    if (!element) {
+      throw new Error(`Passage element not found: ${PASSAGE_SELECTOR}`);
+    }
+
+    const rawText = await page.evaluate((el) => el.textContent, element);
+    const statsText = await page.evaluate((sel) => {
+      const node = document.querySelector(sel);
+      return node ? node.textContent : null;
+    }, STATS_SELECTOR);
+
+    const passage = stripStatsPrefix(rawText, statsText);
+    if (!passage) {
+      throw new Error('Extracted passage was empty after stripping stats');
+    }
+
+    // Type one throwaway key first — this is what starts the timed test on the
+    // site — then type the scraped passage.
+    await page.keyboard.type('j');
+    await typePassage(page.keyboard, passage, { delayMs: config.typingDelayMs });
+  } catch (err) {
+    console.error('[FlashTyper] failed:', err.message);
+    process.exitCode = 1;
+  } finally {
+    // #1124: guaranteed teardown — no orphaned Chrome on any path.
+    if (context) await context.close().catch(() => {});
+    if (browser) await browser.close().catch(() => {});
+  }
 }
 
-(async () => {
-  const puppeteer = require('puppeteer-extra')
-  const pluginStealth = require('puppeteer-extra-plugin-stealth')
-  puppeteer.use(pluginStealth())
+async function main() {
+  await runTyper(resolveConfig());
+}
 
-  const browser = await puppeteer.launch({ headless: false, executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'})
-  const newContext = await browser.createIncognitoBrowserContext()
+if (require.main === module) {
+  main();
+}
 
-  const page = await browser.newPage()
-
-  await page.goto('https://thetypingcat.com/typing-speed-test/1m')
-
-  await sleep(2000)
-
-  //Gets the typing paragraph
-  let element = await page.$("#body > div > div > div:nth-child(3) > div > div.styledComponents__ContentWrapper-sc-1vj1a5a-3.hXkFOq > div.styledComponents__Content-sc-1vj1a5a-0.dIhoFe > div.styledComponents__LaptopWrapper-sc-1vj1a5a-2.iCHJsM > div > div > div:nth-child(2) > div > div.screen.shadow > div > div.screen-display")
-  let textGrabbed = await page.evaluate(el => el.textContent, element)
-
-  //Cuts the extra text from the start of the string
-  textGrabbed = textGrabbed.replace("AccuracySpeedTimeErrors100%0WPM0CPM60s0/0", "");
-
-  //Types Random Key to start the typing test
-  await page.keyboard.type("j")
-
-  //Loops through every character captured
-  for (var i=0; i< textGrabbed.length; i++){
-      if (textGrabbed[i] != "⏎"){
-        await page.keyboard.type(textGrabbed[i], {delay: 0})
-      }else{
-        await page.keyboard.press('Enter');
-      }
-  }
-})()
+module.exports = { runTyper, main, PASSAGE_SELECTOR, STATS_SELECTOR };

--- a/test/fixtures/typing-page.html
+++ b/test/fixtures/typing-page.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>typing fixture</title></head>
+  <body>
+    <div class="screen-display"><span class="stats">AccuracySpeedTimeErrors100%0WPM0CPM60s0/0</span>The quick brown fox⏎jumps over</div>
+    <textarea id="capture"></textarea>
+    <script>document.getElementById('capture').focus();</script>
+  </body>
+</html>

--- a/test/integration/integration.test.js
+++ b/test/integration/integration.test.js
@@ -1,0 +1,65 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const puppeteer = require('puppeteer-extra');
+// Requiring FlashTyper.js registers the stealth plugin on the shared
+// puppeteer-extra instance, so this test file does not register it again.
+const { runTyper, PASSAGE_SELECTOR, STATS_SELECTOR } = require('../../FlashTyper.js');
+const { stripStatsPrefix } = require('../../src/text');
+const { typePassage } = require('../../src/typer');
+
+const FIXTURE_URL = pathToFileURL(
+  path.join(__dirname, '..', 'fixtures', 'typing-page.html')
+).href;
+
+test('runTyper completes cleanly against a local fixture (lifecycle + teardown)', async () => {
+  // runTyper signals failure by setting process.exitCode = 1. Snapshot and
+  // restore the global so this assertion can't leak state into other tests.
+  const initialExitCode = process.exitCode;
+  process.exitCode = 0;
+  try {
+    await runTyper({
+      url: FIXTURE_URL,
+      executablePath: undefined,
+      headless: true,
+      typingDelayMs: 0,
+      waitTimeoutMs: 15000,
+    });
+    assert.equal(process.exitCode, 0, 'runTyper should finish without setting a failure exit code');
+  } finally {
+    process.exitCode = initialExitCode;
+  }
+});
+
+test('scrape + strip + type writes the passage into the focused field', async () => {
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  try {
+    const page = await browser.newPage();
+    await page.goto(FIXTURE_URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector(PASSAGE_SELECTOR, { timeout: 15000 });
+
+    const rawText = await page.evaluate(
+      (sel) => document.querySelector(sel).textContent,
+      PASSAGE_SELECTOR
+    );
+    const statsText = await page.evaluate((sel) => {
+      const node = document.querySelector(sel);
+      return node ? node.textContent : null;
+    }, STATS_SELECTOR);
+
+    const passage = stripStatsPrefix(rawText, statsText);
+    assert.equal(passage, 'The quick brown fox⏎jumps over');
+
+    await page.focus('#capture');
+    await typePassage(page.keyboard, passage, { delayMs: 0 });
+
+    const typed = await page.$eval('#capture', (el) => el.value);
+    assert.equal(typed, 'The quick brown fox\njumps over');
+  } finally {
+    await browser.close();
+  }
+});


### PR DESCRIPTION
## Bucket 2 — Browser Lifecycle & Error Resilience

Rewrites `FlashTyper.js` into a thin orchestrator over the Bucket 1/3 modules, fixing the remaining lifecycle and resilience bugs. Closes the rest of the audit.

### Fixes
- **#1123** — opens the page from `browser.createBrowserContext()` (the isolated context is now actually used; old code created it then opened on the default context). Uses the current, non-deprecated API.
- **#1124** — whole run wrapped in `try/catch/finally`; `context.close()` then `browser.close()` always run, so a failure no longer leaves an orphaned Chrome. Errors set `process.exitCode = 1`.
- **#1121** — null guard on the scraped element (covers the detach-between-`waitForSelector`-and-`$` race).
- **#1125** — fixed `sleep(2000)` replaced with `waitForSelector` for real readiness.
- **#1127 (selector half)** — `PASSAGE_SELECTOR = '.screen-display'` (stable class, not a styled-components hash); stats cleanup uses the dynamic `stripStatsPrefix` from Bucket 3.

### Tests
- Offline fixture (`test/fixtures/typing-page.html`) + 2 integration tests: one asserts the full `runTyper` lifecycle completes cleanly (and tears down); one asserts the real scrape→strip→type pipeline writes the expected passage (incl. `⏎`→Enter newline) into a focused field.
- `npm test` → 15 unit passed; `npm run test:integration` → 2 passed.

### Reviewer follow-ups applied
- Snapshot/restore `process.exitCode` in the lifecycle test to prevent global-state bleed between tests.
- Register the stealth plugin once at module load (not per `runTyper` call); dropped the redundant registration in the integration test.
- Sharpened the null-guard and start-keystroke comments.